### PR TITLE
Point to aws-vault fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ This repository contains the source of the [Chocolatey package] for [AWS Vault] 
 For more information please see [the original repository][AWS Vault].
 
 [Chocolatey package]: https://chocolatey.org/packages/aws-vault/
-[AWS Vault]: https://github.com/99designs/aws-vault/
-[99designs]: https://99designs.com/
+[AWS Vault]: https://github.com/ByteNess/aws-vault/
+[99designs]: https://99designs.com

--- a/src/chef/cookbooks/chocolatey-package/attributes/default.rb
+++ b/src/chef/cookbooks/chocolatey-package/attributes/default.rb
@@ -1,7 +1,7 @@
 default['chocolatey-package'] = {
   'id' => 'aws-vault',
   'title' => 'AWS Vault',
-  'project-source-url' => 'https://github.com/99designs/aws-vault/',
+  'project-source-url' => 'https://github.com/ByteNess/aws-vault/',
   'project-version' => ENV['CHOCOLATEY_PROJECT_VERSION'],
   'package-source-url' => 'https://github.com/gusztavvargadr/aws-vault-chocolatey/',
   'package-version' => ENV['CHOCOLATEY_PACKAGE_VERSION'],


### PR DESCRIPTION
aws-vault project is abandoned and a there's a fork: https://github.com/99designs/aws-vault/pull/1270