### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
           path: artifacts/chocolatey/
 
       - name: Read version from package.json
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: read-version
         shell: pwsh
         run: |
@@ -49,7 +49,7 @@ jobs:
           Write-Host "Version: $version"
 
       - name: Find previous version
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: find-previous
         shell: pwsh
         run: |
@@ -90,11 +90,11 @@ jobs:
           Write-Host "Previous version: $previousVersion"
 
       - name: Generate release notes for draft
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: dotnet cake --target GenerateDraftReleaseNotes --release-version ${{ steps.read-version.outputs.version }} --release-previous-version ${{ steps.find-previous.outputs.version }}
 
       - name: Create or update draft release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.read-version.outputs.version }}


### PR DESCRIPTION
## Summary

This pull request makes a small update to the GitHub Actions workflow for continuous deployment. The conditional checks on several steps have been simplified to trigger on any event as long as the branch is `main`, instead of only on `push` events.

- Simplified workflow conditions in `.github/workflows/cd.yml` by removing the `github.event_name == 'push'` check, so steps now run on any event for the `main` branch. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L42-R42) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L52-R52) [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L93-R97)